### PR TITLE
Warn on empty instance name instead of failure.

### DIFF
--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -268,7 +268,7 @@ func DialRaw(ctx context.Context, params DialParams) (*grpc.ClientConn, error) {
 // functionality.
 func NewClient(ctx context.Context, instanceName string, params DialParams, opts ...Opt) (*Client, error) {
 	if instanceName == "" {
-		return nil, fmt.Errorf("instance needs to be specified")
+		log.Warning("Instance name was not specified.")
 	}
 	if params.Service == "" {
 		return nil, fmt.Errorf("service needs to be specified")


### PR DESCRIPTION
As stated in the [design doc](https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvroblTZ_6s/), `instance name` should be allowed to be empty.